### PR TITLE
Make Kerreru Filters Persistent

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -15,6 +15,7 @@ class RecordsController < ApplicationController
 
   def index
     params[:i] = sanitize_hash(params[:i]) if params[:i]
+    params[:or] = sanitize_hash(params[:or]) if params[:or]
 
     SearchTab.add_category_facets(@search, params[:tab])
     @records = @search.results
@@ -47,6 +48,6 @@ class RecordsController < ApplicationController
   # Params Hash  saved as hidden fields when passed back into
   # the controller needs to be sanitized.
   def sanitize_hash(params_i)
-    eval params_i.to_s.gsub("\"", "'").gsub(":", "=>")
+    eval params_i.to_s.gsub("'", "\\\\'").gsub("\"", "'").gsub(":", "=>")
   end
 end

--- a/app/views/shared/_search.html.haml
+++ b/app/views/shared/_search.html.haml
@@ -7,6 +7,11 @@
   \# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
   \# http://digitalnz.org/supplejack
 = form_tag records_path, :method => :get, class: 'search clearfix' do
+  - if params[:or].present?
+    - params['or'].each do |k, v|
+      - v.each do |v|
+        = hidden_field_tag "or[#{k}][]", v
+
   - if params[:i].present?
     - params[:i].each do |k, v|
       = hidden_field_tag "i[#{k}]", v


### PR DESCRIPTION
*Acceptance Criteria*
- All search filters are persistent until removed by the user
- Sifter ticket is closed

*Notes*
*Note that this was working when we approved the story last sprint and has regressed.
*Multi-selected filter options under a single field are lost when pressing the search button.

SIFTER TICKET:
Kereru: Multi-select not persistent when searching
https://boost.sifterapp.com/issues/7193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_website/20)
<!-- Reviewable:end -->
