### PR TITLE
ADD KERERU STATIC PAGES

### DIFF
--- a/app/assets/stylesheets/supplejack/general.scss
+++ b/app/assets/stylesheets/supplejack/general.scss
@@ -119,6 +119,13 @@ footer {
 	}
 }
 
+.top-bar-section{
+	ul{
+		li > a{
+				color: #fff;
+					}
+		}
+}
 
 .filters-button {
 	margin: 1em 0;

--- a/app/assets/stylesheets/supplejack/general.scss
+++ b/app/assets/stylesheets/supplejack/general.scss
@@ -7,9 +7,23 @@ a, button, input, textarea {
 body {
 	font-family: 'Raleway';
 }
-
 .button {
 	background: $brand-colour;
+}
+
+footer {
+	padding: 4em 0;
+	border-top: 1px solid #eaeaea;
+	a {
+		color: #777;
+		line-height: 2em;
+		padding: 0 15px;
+	}
+	nav{
+		max-width: 62.5rem;
+		margin: 0 auto;
+		margin-bottom: 0;
+	}
 }
 
 .home {

--- a/app/assets/stylesheets/supplejack/general.scss
+++ b/app/assets/stylesheets/supplejack/general.scss
@@ -127,6 +127,23 @@ footer {
 		}
 }
 
+.top-bar-section {
+	.dropdown{
+		li.title{
+			h5{
+				a{
+					color: #fff;
+				}
+			}
+		}
+		li.parent-link{
+			a{
+				color: #fff;
+			}
+		}
+	}
+}
+
 .filters-button {
 	margin: 1em 0;
 }

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -11,6 +11,8 @@
     %nav
       / <haml_loud> link_to &quot;Become a Partner&quot;, become_a_partner_path </haml_loud>
       / <haml_loud> link_to &quot;Contact&quot;, contact_path </haml_loud>
+      = link_to "About", about_path
+      = link_to "Contact", contact_path
       = link_to "Terms of use", terms_path
 
 = javascript_include_tag "application"

--- a/app/views/shared/_menu.html.haml
+++ b/app/views/shared/_menu.html.haml
@@ -16,8 +16,10 @@
     %section.top-bar-section
       %ul.left
         %li#home-link= link_to 'Home', root_url
-        %li#contact-link= link_to 'Contact', '/contact'
         %li#about-link= link_to 'About', '/about'
+        %li#contact-link= link_to 'Contact', '/contact'
+        %li#terms-link= link_to 'Terms of Use', '/terms'
+
         / - unless current_page? root_url
         /   %li.has-form
         /     .row.collapse
@@ -27,7 +29,8 @@
         /           = text_field_tag :text, @search.text, class: 'search-input', placeholder: t('records.enter_search')
         /         .large-4.small-3.columns
         /           = submit_tag "Search", class: "button postfix"
-                
+
+
       %ul.right
         - if user_signed_in?
           %li.has-dropdown
@@ -36,7 +39,6 @@
             %ul.dropdown
               %li= link_to 'Edit profile', edit_user_registration_path, id: 'edit-profile-link'
               %li= link_to "Logout", destroy_user_session_path, method: :delete, id: 'logout-link'
-        - else 
+        - else
           %li= link_to "Sign up", new_user_registration_path, id: 'sign-up-link'
           %li= link_to "Login", new_user_session_path, id: 'login-link'
-

--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -11,7 +11,7 @@
 
   %p
     Welcome to
-    %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+    %a{:href => "http://beta.digitalnz.org"} beta.digitalnz.org
     the next step in DigitalNZ’s evolution. Here we’re developing and testing new and improved ways for you to find, share, and use amazing New Zealand content. As with the current
     = succeed "," do
       %a{:href => "http://www.digitalnz.org"} digitalnz.org
@@ -33,7 +33,7 @@
 
   %p
     Over the course of 2016 and beyond, we’ll be tracking our
-    %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+    %a{:href => "http://beta.digitalnz.org"} beta.digitalnz.org
     work
     = succeed "." do
       %a{:href => "https://docs.google.com/document/d/1A2OvFy5gLArgQiTt_9JsnR12PGSQUbTqaZpYOIoTvOM/edit", :target => '_blank'} here in our release notes

--- a/app/views/static_pages/about.html.haml
+++ b/app/views/static_pages/about.html.haml
@@ -8,9 +8,35 @@
   \# http://digitalnz.org/supplejack
 .container.static
   %h1 About
-  %p This website demo is part of the standard Supplejack platform that can aggregate data and content from many different sources. This website connects to harvested content via the Supplejack API. The default configuration of this website assumes the use of common schema elements and matching test data.
-  %p If you are not seeing the expected content in this demo, you may need to either check you have harvested the right data, update your schema in the supplejack_api, or update your connecting fields in the supplejack_client and supplejack_website applications.
+
   %p
-    The standard search tabs and filter options are populated dynamically based on top record counts, and can be overridden in the supplejack_website application. You can find further details at
+    Welcome to
+    %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+    the next step in DigitalNZ’s evolution. Here we’re developing and testing new and improved ways for you to find, share, and use amazing New Zealand content. As with the current
+    = succeed "," do
+      %a{:href => "http://www.digitalnz.org"} digitalnz.org
+    you can browse, search, and discover New Zealand archives, photos, artworks, artefacts, data, news reports, and many other types of material, from nearly 200 organisations. But we also have a number of other exciting services planned.
+
+  %p
+    Our goal for 2016 is to develop a fresher, more user-friendly and lovely-to-look-at version of
     = succeed "." do
-      %a{:href => "http://www.digitalnz.org/supplejack"} www.digitalnz.org/supplejack
+      %a{:href => "http://www.digitalnz.org"} digitalnz.org
+    Our approach to this is a little different because we are developing beta.digitalnz.org iteratively. That means we’re starting with a very basic version of the website and we’ll regularly make both small and substantial changes to this website throughout 2016 and beyond. These changes will often be based on your feedback, so any thoughts you have for us are hugely helpful and will feed directly into the site’s development.
+
+  %p
+    You can let us know what you think by clicking the red “Feedback” button on the lower right-hand corner of this page, or email us at
+    = succeed "." do
+      %a{:href => 'mailto:info@digitalnz.org', :target => '_blank'} info@digitalnz.org
+    We’d love to hear from you.
+
+  %h3 Release notes
+
+  %p
+    Over the course of 2016 and beyond, we’ll be tracking our
+    %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+    work
+    = succeed "." do
+      %a{:href => "https://docs.google.com/document/d/1A2OvFy5gLArgQiTt_9JsnR12PGSQUbTqaZpYOIoTvOM/edit", :target => '_blank'} here in our release notes
+    These include notes about parts of the site that may not be quite right, and it’ll give you an idea of what is coming next.
+
+  %p If you’re concerned that we’re missing something, or a part of the site isn’t working properly, check here first, as it is likely that we’re working on it and an update will be released soon.

--- a/app/views/static_pages/contact.html.haml
+++ b/app/views/static_pages/contact.html.haml
@@ -11,7 +11,7 @@
   %p
     If you have any feedback, questions, gripes, or kind words about
     = succeed "," do
-      %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+      %a{:href => "http://beta.digitalnz.org"} beta.digitalnz.org
     we’d love to hear from you.
 
   %p

--- a/app/views/static_pages/contact.html.haml
+++ b/app/views/static_pages/contact.html.haml
@@ -8,3 +8,26 @@
   \# http://digitalnz.org/supplejack
 .container.static
   %h1 Contact
+  %p
+    If you have any feedback, questions, gripes, or kind words about
+    = succeed "," do
+      %a{:href => "http://www.beta.digitalnz.org"} beta.digitalnz.org
+    we’d love to hear from you.
+
+  %p
+    You can send us feedback directly by clicking on the red “Feedback” button on the lower right-hand corner of this page.
+
+  %p
+    You can also email us on
+    = succeed "," do
+      %a{:href => 'mailto:info@digitalnz.org', :target => '_blank'} info@digitalnz.org
+    chat with us on
+    = succeed "," do
+      %a{:href => "https://twitter.com/digitalnz", :target => '_blank'} Twitter
+    or post to our
+    %a{:href => "https://www.facebook.com/digitalnz/", :target => '_blank'} Facebook
+    page. We’ll also be regularly posting on
+    %a{:href => "http://www.digitalnz.org/blog/posts/changes-afoot-in-2016", :target => '_blank'} our blog
+    and in
+    %a{:href => "https://docs.google.com/document/d/1A2OvFy5gLArgQiTt_9JsnR12PGSQUbTqaZpYOIoTvOM/edit?pref=2&pli=1", :target => '_blank'} our release notes
+    about the work we’re doing and the changes we’re making to the site.

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -18,9 +18,9 @@
 
   %p Each registered user of this website (including use of your “dashboard”, the DigitalNZ API and any search widgets or other tools provided) has the following responsibilities:
 
-  %p You agree to keep your user ID, password secure. Do not disclose your password [or forgotten password phrase] to anyone else.
-
-  %p If you think someone knows your user ID, password, you must immediately: change your password, or cancel your online account for this website, or call us.
+  %ul
+    %li You agree to keep your user ID, password secure. Do not disclose your password [or forgotten password phrase] to anyone else.
+    %li If you think someone knows your user ID, password, you must immediately: change your password, or cancel your online account for this website, or call us.
 
   %p You must keep your registration details up-to-date. You are responsible for providing all hardware and software required to perform your obligations under these terms of use.
 

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -8,3 +8,108 @@
   \# http://digitalnz.org/supplejack
 .container.static
   %h1 Terms of Use
+  %p We welcome you to this website and encourage you to use the Digital New Zealand services. By using this website you agree to be legally bound by these terms of use which take effect immediately on your first use of the website. If you do not agree to be legally bound by all these terms, please do not access or use this website.
+
+  %p The Digital New Zealand project is run by the National Library of New Zealand (“the National Library”). The National Library may change this website, the online services (“the Service”) provided through it or the terms of use at any time.
+
+  %pChanges to these terms of use will be posted online. You are responsible for reviewing the amended terms of use, and your continued use of this website constitutes your agreement to the amended terms of use.
+
+  %h3 Your responsibilities
+
+  %p Each registered user of this website (including use of your “dashboard”, the DigitalNZ API and any search widgets or other tools provided) has the following responsibilities:
+
+  %p You agree to keep your user ID, password secure. Do not disclose your password [or forgotten password phrase] to anyone else.
+
+  %p If you think someone knows your user ID, password, you must immediately: change your password, or cancel your online account for this website, or call us.
+
+  %p You must keep your registration details up-to-date. You are responsible for providing all hardware and software required to perform your obligations under these terms of use.
+
+  %h3 Tools
+
+  %p You may use the search facility, search widgets and other tools provided by this website for the purposes designated by this website but in any event only for non-commercial purposes. You may embed search widgets (“search widgets”) and other tools you create using this website on another website, blog, or in an application (“Other Website”) in accordance with these terms.
+
+  %p All search queries (“Search Queries”) sent to the National Library from the Other Website using search widgets shall comply with the technical specifications that the National Library may issue from time to time. The National Library will process Search Queries using the National Library's search engine. If you receive a Search Query from a user of the Other Website (“User”) the Other Website must forward that Search Query to the National Library. You must not in any way modify or re-contextualise the Results produced by the National Library’s search engine, except as otherwise agreed between you and the National Library. The National Library is not responsible for the transmission of data between you and the National Library.
+
+  %p The search widget or other tool embedded on the Other Website must clearly indicate that the widget or tool is provided by Digital New Zealand.
+
+  %p You must not and must not allow any third party to:
+
+  %ul
+    %li modify any Results
+    %li prevent the complete display of any Results
+    %li assign or otherwise dispose of a search widget or any Service
+    %li use a search widget or any Service for any commercial purpose or seek any payment or other remuneration for the provision of a search widget or any Service
+    %li remove or modify the National Library's trade marks, copyright notice or trade mark notice associated with any search widget or Service, or
+    %li engage in any conduct that reflects poorly on the National Library and Digital New Zealand
+
+  %p The Other Website must not contain any indecent, obscene or violent content or contain any other material, products or services that breach or encourage conduct that would breach any applicable laws (such as the Human Rights Act (NZ)) or third party rights, including intellectual property rights.
+
+  %h3 Acceptable use
+
+  %p You agree not to use search widgets and other tools, the Digital New Zealand API, the Digital New Zealand content, or the National Library trade marks in any way that is unlawful, or harms the National Library, its service providers, its suppliers, your end users, or any other person.
+
+  %p The National Library may unilaterally suspend your use of search widgets and other tools, the Digital New Zealand API, the Digital New Zealand content and/or the National Library trade marks if and when the National Library determines that your use breaches the terms of use or is otherwise unacceptable.
+
+  %h3 Trade marks
+
+  %p The National Library grants you a non-transferable, non-exclusive licence while you remain a registered user of this website to display the National Library's trade marks, including DIGITAL NEW ZEALAND, in relation to your use of the Service, search widgets and tools as permitted by this website.
+
+  %p Your use of the National Library’s trade marks is subject to the Digital New Zealand brand guidelines as issued from time to time. All use of the National Library's trade marks (including any goodwill associated with it) shall inure to the benefit of the National Library.
+
+  %p If the National Library determines at any time that you are using or displaying any of the National Library’s trade marks in a manner that is or may be detrimental to the National Library’s interests, the National Library may issue reasonable instructions to you concerning the manner, if any, in which you may continue the use of such the National Library’s trade marks or any of them. You must promptly comply with such instructions or cease the use or display of the relevant National Library trade mark.
+
+  %h3 Content disclaimer
+
+  %p This website contains content that was not produced by the National Library. The National Library is not responsible for such third-party content, and does not necessarily endorse the views expressed in it. The Library accepts no liability or responsibility for the manner in which the information on this website is interpreted or used, or the results of such use.
+
+  %h3 External links from this website
+
+  %p This website may include hypertext links to the websites of other people and organisations. Linking should not be taken as endorsement of any kind by the National Library of those other people and organisations.
+
+  %p The National Library is not responsible for the content of external internet sites and does not necessarily endorse the views expressed within them. Contact the external site owner for answers to questions regarding their content.
+
+  $h3 User contributed metadata
+
+  %p As a DigitalNZ user you may submit descriptive information ("User Contributed Metadata") about content available through DigitalNZ. User Contributed Metadata includes comments, descriptions, tags, and other metadata submitted to DigitalNZ.
+
+  %p You grant the National Library a worldwide, non-exclusive, royalty-free, perpetual, sublicenseable and transferable license to use, reproduce, distribute, modify, and display your User Contributed Metadata. You understand and agree that this can be redistributed in any format and through any channel, including the DigitalNZ websites and the DigitalNZ API.
+
+  %h3 Linking to this website
+
+  %p You are welcome to link to pages on this website. Links should not state or imply that the material is the copyright of anyone other than the National Library or the relevant copyright holder.
+
+  %p Linking to this website from any other website or organisation is not an endorsement of any kind by the National Library.
+
+  %h3 Security and damage
+
+  %p You are responsible for any damage you cause to this website or to any of the National Library’s other websites, electronic facilities or data.
+
+  %p We provide security to protect this website and our online services. You are responsible for ensuring that your own computer is secure, including taking all reasonable steps to:
+
+  %ul
+    %li prevent someone misusing or getting unauthorised access to your computer system or to this website or our online services, and
+    %li ensure your computer system and data are free of computer viruses and all other forms of corruption.
+
+  %h3 Disclaimer
+
+  %p The National Library makes no warranty, express or implied, nor assumes any legal liability or responsibility:
+  %ul
+    %li that this website or the National Library’s servers are free of computer viruses or any other harmful components, defects or errors
+    %li that any defects in this website will be corrected
+    %li that your access to this website will be reliable, uninterrupted or error-free (including access to any linked applications, search widgets and other tools)
+    %li for any delays, inaccuracies, failures, errors, omissions, interruptions, deletions, defects, computer viruses or communication line failures, or
+    %li for any theft, destruction, damage or unauthorised access to your computer system or network.
+
+  %p Users of this website assume all risks associated with any transfer of data or information to the National Library, and with any other use of this website. We are not liable for any damage arising from interception, loss, theft, other action or difficulty in transmitting information to us.
+
+  %p You agree that the National Library shall not under any circumstances be liable for any direct, indirect, incidental, special, consequential or exemplary loss or damages whatsoever resulting from or arising in relation to the Content, this website or the online services of the National Library or the use of them.
+
+  %h3 Suspension of access
+
+  %p The National Library may, at its discretion, suspend or restrict your access to this website or any part of it for any reason, including a breach of these terms of use.
+
+  %h3 Governing law
+
+  %p This website and these terms and conditions are governed by the laws of New Zealand and the courts of New Zealand have non-exclusive jurisdiction in relation to them.
+
+  %p These terms and conditions are without prejudice to the powers, rights and duties of the National Library under the National Library of New Zealand (Te Puna Mātauranga o Aotearoa) Act 2003.

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -12,7 +12,7 @@
 
   %p The Digital New Zealand project is run by the National Library of New Zealand (“the National Library”). The National Library may change this website, the online services (“the Service”) provided through it or the terms of use at any time.
 
-  %pChanges to these terms of use will be posted online. You are responsible for reviewing the amended terms of use, and your continued use of this website constitutes your agreement to the amended terms of use.
+  %p Changes to these terms of use will be posted online. You are responsible for reviewing the amended terms of use, and your continued use of this website constitutes your agreement to the amended terms of use.
 
   %h3 Your responsibilities
 

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -68,7 +68,7 @@
 
   %p The National Library is not responsible for the content of external internet sites and does not necessarily endorse the views expressed within them. Contact the external site owner for answers to questions regarding their content.
 
-  $h3 User contributed metadata
+  %h3 User contributed metadata
 
   %p As a DigitalNZ user you may submit descriptive information ("User Contributed Metadata") about content available through DigitalNZ. User Contributed Metadata includes comments, descriptions, tags, and other metadata submitted to DigitalNZ.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 # The majority of The Supplejack Website code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or other terms. 
-# See https://github.com/DigitalNZ/supplejack_website for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or other terms.
+# See https://github.com/DigitalNZ/supplejack_website for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 Demo::Application.routes.draw do

--- a/spec/controllers/static_page_controllers_spec.rb
+++ b/spec/controllers/static_page_controllers_spec.rb
@@ -1,26 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe StaticPagesController do
-
-  describe "GET 'about'" do
-    it "returns http success" do
-      get :about
-      expect(response.status).to eq 200
-    end
+  it "about page is successful" do
+    get :about
+    expect(response.status).to eq 200
   end
 
-  describe "GET 'contact'" do
-    it "returns http success" do
-      get :contact
-      expect(response.status).to eq 200
-    end
+  it "contact page is successful" do
+    get :contact
+    expect(response.status).to eq 200
   end
 
-  describe "GET 'terms'" do
-    it "returns http success" do
-      get :terms
-      expect(response.status).to eq 200
-    end
+  it "terms page is successful" do
+    get :terms
+    expect(response.status).to eq 200
   end
-
 end

--- a/spec/controllers/static_page_controllers_spec.rb
+++ b/spec/controllers/static_page_controllers_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe StaticPagesController do
+
+  describe "GET 'about'" do
+    it "returns http success" do
+      get :about
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "GET 'contact'" do
+    it "returns http success" do
+      get :contact
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "GET 'terms'" do
+    it "returns http success" do
+      get :terms
+      expect(response.status).to eq 200
+    end
+  end
+
+end


### PR DESCRIPTION
Acceptance criteria
All 3 pages, 'About', 'Contact', and 'Terms of use' added to kereru
Pages are linked to from the top grey nav bar on kereru
Text and formatting for each page reflects the attached document and notes below.
Top nav should have: Home, Contact, About, and Terms of use
Footer should have: Contact, About, and Terms of use